### PR TITLE
Enable stream scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 DiffParser
 ===========
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/Nomango/diffparser)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/vitrifi/diffparser)
 
 DiffParser is a Golang package which parse's a git diff.
 
@@ -8,7 +8,7 @@ Install
 -------
 
 ```sh
-go get github.com/Nomango/diffparser
+go get github.com/vitrifi/diffparser
 ```
 
 Usage Example
@@ -19,7 +19,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/Nomango/diffparser"
+	"github.com/vitrifi/diffparser"
 )
 
 // error handling left out for brevity

--- a/README.md
+++ b/README.md
@@ -18,14 +18,15 @@ Usage Example
 package main
 
 import (
-	"fmt"
+	"os"
 	"github.com/vitrifi/diffparser"
 )
 
 // error handling left out for brevity
 func main() {
-	byt, _ := ioutil.ReadFile("example.diff")
-	diff, _ := diffparser.Parse(string(byt))
+	f, _ := os.Open("example.diff")
+	defer f.Close()
+	diff, _ := diffparser.ParseStream(f)
 
 	// You now have a slice of files from the diff,
 	file := diff.Files[0]

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Nomango/diffparser
+module github.com/vitrifi/diffparser
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,6 @@ module github.com/vitrifi/diffparser
 go 1.12
 
 require (
-	github.com/davecgh/go-spew v1.1.1
-	github.com/pmezard/go-difflib v1.0.0
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/stretchr/testify v1.4.0
-	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.0.0-20160715033755-e4d366fc3c79/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
This stream scanning implementation is added "inside" the existing string based Parse functions to ensure backwards compatibility and to reuse the existing test suite.

The reason for this change is to reduce the memory usage of the parser for stream based sources, mostly files. Rather than having to read an entire file into memory it can instead be streamed in chunks.

We've been making use of your fork of https://github.com/waigani/diffparser because it has some critical fixes around renamed files.

However an additional issue that we noticed was that when trying to diff larger files they both need to be read into memory before they can be parsed, so we added a streaming implementation which resolves that issue.

If you would rather we can switch this PR to the waigani project, but it seems to be pretty inactive right now, but we am happy to do so if you would rather we did that.